### PR TITLE
Adjusts requirements.txt to work with binder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
-jupyter
-matplotlib>=2.0
-numpy
-pandas
-scikit-learn>=0.18
-scipy>=0.19
-seaborn
-folium
-geopandas
-datashader
+name: cdips-mapping
+
+dependencies:
+ - jupyter
+ - matplotlib>=2.0
+ - numpy
+ - pandas
+ - scikit-learn>=0.18
+ - scipy>=0.19
+ - seaborn
+ - folium
+ - geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ scikit-learn>=0.18
 scipy>=0.19
 seaborn
 folium
-geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
-name: cdips-mapping
-
-dependencies:
- - jupyter
- - matplotlib>=2.0
- - numpy
- - pandas
- - scikit-learn>=0.18
- - scipy>=0.19
- - seaborn
- - folium
- - geopandas
+jupyter
+matplotlib>=2.0
+numpy
+pandas
+scikit-learn>=0.18
+scipy>=0.19
+seaborn
+folium
+geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ pandas
 scikit-learn>=0.18
 scipy>=0.19
 seaborn
+folium
+geopandas
+datashader


### PR DESCRIPTION
For now, that just means adding `folium`, but that may end up including `geopandas` as well. We ran into issues with `gdal` and `datashader` and other packages that required installs from outside the normal conda channel, so `folium` and `geopandas` are the only two addt'l packages we'll need.

